### PR TITLE
Scoping

### DIFF
--- a/.github/workflows/public-api.yml
+++ b/.github/workflows/public-api.yml
@@ -19,7 +19,8 @@ jobs:
         run: |
           set -euxo pipefail
 
-          rustup install nightly --profile minimal
+          rustup install nightly-2024-10-11 --profile minimal
+          mv ~/.rustup/toolchains/nightly-2024-07-05-x86_64-unknown-linux-gnu ~/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu
 
       - name: Install public-api
         uses: baptiste0928/cargo-install@v3

--- a/.github/workflows/public-api.yml
+++ b/.github/workflows/public-api.yml
@@ -20,7 +20,7 @@ jobs:
           set -euxo pipefail
 
           rustup install nightly-2024-10-11 --profile minimal
-          mv ~/.rustup/toolchains/nightly-2024-07-05-x86_64-unknown-linux-gnu ~/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu
+          mv ~/.rustup/toolchains/nightly-2024-10-11-x86_64-unknown-linux-gnu ~/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu
 
       - name: Install public-api
         uses: baptiste0928/cargo-install@v3

--- a/examples/macroquad-example/src/main.rs
+++ b/examples/macroquad-example/src/main.rs
@@ -46,7 +46,7 @@ fn layout_for_highlight(ctx: &mut State) -> Node<State> {
         vec![
             scope(
                 |state: &mut State| &mut state.highlight,
-                rel_abs_seq(ctx.highlight),
+                |highlight| rel_abs_seq(*highlight),
             ),
             if highlight == HighlightedCase::AlignmentOffset || highlight == HighlightedCase::None {
                 column_spaced(

--- a/src/clone.rs
+++ b/src/clone.rs
@@ -49,7 +49,12 @@ impl<State> Clone for NodeValue<State> {
             },
             NodeValue::Group(elements) => NodeValue::Group(elements.clone()),
             NodeValue::Space => NodeValue::Space,
-            NodeValue::Scope { scope, scoped } => NodeValue::Scope {
+            NodeValue::Scope {
+                node,
+                scope,
+                scoped,
+            } => NodeValue::Scope {
+                node: node.clone(),
                 scope: scope.clone(),
                 scoped: scoped.clone(),
             },

--- a/src/clone.rs
+++ b/src/clone.rs
@@ -49,7 +49,8 @@ impl<State> Clone for NodeValue<State> {
             },
             NodeValue::Group(elements) => NodeValue::Group(elements.clone()),
             NodeValue::Space => NodeValue::Space,
-            NodeValue::Scope { scoped } => NodeValue::Scope {
+            NodeValue::Scope { scope, scoped } => NodeValue::Scope {
+                scope: scope.clone(),
                 scoped: scoped.clone(),
             },
             NodeValue::Empty => NodeValue::Empty,

--- a/src/constraints.rs
+++ b/src/constraints.rs
@@ -153,7 +153,9 @@ impl<State> NodeValue<State> {
                     state,
                 )),
             NodeValue::Offset { element, .. } => element.constraints(allocations[0], state),
-            NodeValue::Scope { scoped, .. } => scoped.constraints(allocations[0], state),
+            NodeValue::Scope { scope, scoped } => {
+                scoped(scope(state)).constraints(allocations[0], state)
+            }
             NodeValue::Draw(_) | NodeValue::Space | NodeValue::AreaReader { .. } => {
                 SizeConstraints {
                     width: Constraint::none(),

--- a/src/constraints.rs
+++ b/src/constraints.rs
@@ -153,9 +153,14 @@ impl<State> NodeValue<State> {
                     state,
                 )),
             NodeValue::Offset { element, .. } => element.constraints(allocations[0], state),
-            NodeValue::Scope { scope, scoped } => {
-                scoped(scope(state)).constraints(allocations[0], state)
-            }
+            NodeValue::Scope { node, .. } => node
+                .as_mut()
+                .map(|node| node.constraints(allocations[0], state))
+                .unwrap_or(SizeConstraints {
+                    width: Constraint::none(),
+                    height: Constraint::none(),
+                    aspect: None,
+                }),
             NodeValue::Draw(_) | NodeValue::Space | NodeValue::AreaReader { .. } => {
                 SizeConstraints {
                     width: Constraint::none(),

--- a/src/debug.rs
+++ b/src/debug.rs
@@ -54,7 +54,11 @@ impl<State> fmt::Debug for NodeValue<State> {
             NodeValue::Space => write!(f, "Space"),
             NodeValue::Empty => write!(f, "Empty"),
             NodeValue::AreaReader { .. } => write!(f, "WidthReader"),
-            NodeValue::Scope { scoped } => f.debug_struct("Scope").field("scoped", scoped).finish(),
+            NodeValue::Scope { .. } => f
+                .debug_struct("Scope")
+                .field("scope", &"<function>")
+                .field("scoped", &"<function>")
+                .finish(),
             NodeValue::Coupled {
                 element,
                 coupled,

--- a/src/nodes.rs
+++ b/src/nodes.rs
@@ -132,6 +132,7 @@ pub fn scope<T, U: 'static>(
 ) -> Node<T> {
     Node {
         inner: NodeValue::Scope {
+            node: None,
             scope: Rc::new(move |i| scope(i)),
             scoped: Rc::new(move |i| {
                 let anynode = node(i.downcast_mut::<U>().expect("Invalid downcast"));
@@ -162,6 +163,7 @@ pub fn scope<T, U: 'static>(
                             .expect("Invalid downcast")
                             .inner
                             .constraints(area, scope(state));
+                        dbg!(scoped);
                         SizeConstraints {
                             width: scoped.width,
                             height: scoped.height,

--- a/src/tests/layout_tests.rs
+++ b/src/tests/layout_tests.rs
@@ -681,8 +681,18 @@ mod tests {
                 draw(|area, _: &mut TupleA| {
                     assert_eq!(area, Area::new(0., 0., 100., 100.));
                 }),
-                // This sort of partial scoping seems to be impossible to implement with the current API
+                // TODO: This sort of partial scoping seems to be impossible to implement with the current API
                 // I would like to find a way to make it possible! but how??
+                //
+                // The Any type is used because rust recursive polymorphism isn't really supported
+                //
+                // UI frameworks like egui offer an &mut <UIHandle> when you create your UI elements
+                // & you often have some of your own app state to pass through the layout tree
+                //
+                // You can easily scope when your state is just &mut B, but you can't scope B in &mut (&mut A, &mut B)
+                // because the closure can't return a reference to a temporary tuple
+                //
+                //
                 // scope(|t: &mut TupleA| &mut (&mut *t.0, &mut *t.1), |_| space()),
             ])
         }

--- a/src/tests/layout_tests.rs
+++ b/src/tests/layout_tests.rs
@@ -635,5 +635,8 @@ mod tests {
         Layout::new(layout).draw(Area::new(0., 0., 100., 100.), &mut a);
         assert!(!a.test);
         assert!(!a.b.test);
+        Layout::new(layout).draw(Area::new(0., 0., 100., 100.), &mut a);
+        assert!(a.test);
+        assert!(a.b.test);
     }
 }


### PR DESCRIPTION
This Approach:
 - ✅ Fixes half baked scoping with the single state case
 - ⚠️ Partial scoping is impossible given &mut Ui, &mut ViewStateIWantToScope

Multiple state generics: https://github.com/ejjonny/backer/tree/multistate
 - ✅ Compiles without workarounds
 - ✅ Enables partial scoping given &mut Ui, &mut ViewStateIWantToScope
 - ⚠️ Really doesn't scale, maybe that's fine
 - ⚠️ Noisy API to account for the single generic use case

Trait based scoping: https://github.com/ejjonny/backer/tree/trait-scoping
 - ✅ Eliminates the need for AnyNode & related lifetime trouble
 - ⚠️ Actually conforming to `Scopable` as a user seems to be complex or error prone due to some recursive conformance checks? I can't even get the partial scoping test to compile..
 - ❌ Requires manual drop as a workaround for [this issue](https://github.com/rust-lang/rust/issues/44933)
 - ❌ Causes clippy [eternal lint issue](https://github.com/rust-lang/rust-clippy/issues/13544)